### PR TITLE
Extend GraphQL request schema to pull statistics for PRs

### DIFF
--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -62,6 +62,9 @@ gql_template = """\
         mergeCommit {{
           oid
         }}
+        deletions
+        additions
+        changedFiles
         {comments}
       }}
       ... on Issue {{


### PR DESCRIPTION
Hi!
As part of our efforts to analyze how well we're doing in handling community contributions, MariaDB Foundation ended up using this awesome tool for pulling GitHub activity from MariaDB/server repo. In this process we realized it's useful to have some more statistics for each PR (lines added, lines deleted, number of changed files).
Here's is what we changed to make this work. If you think this may break existing apps/script using github-activity, I can include this functionality under a "--include-pr-stats" option.

Many thanks for this work and please let me know if there's anything I can help with.