### PR TITLE
Fail early on missing GitHub api credentials

### DIFF
--- a/github_activity/graphql.py
+++ b/github_activity/graphql.py
@@ -92,12 +92,18 @@ class GitHubGraphQlQuery:
         self.query = query
 
         # Authentication
-        headers = {}
-        auth = os.environ.get("GITHUB_ACCESS_TOKEN") if auth is None else auth
-        if auth is not None:
-            headers.update({"Authorization": "Bearer %s" % auth})
+        auth = auth or os.environ.get("GITHUB_ACCESS_TOKEN")
+        if not auth:
+            raise ValueError(
+                "Either the environment variable GITHUB_ACCESS_TOKEN or the "
+                "--auth flag or must be used to pass a Personal Access Token "
+                "needed by the GitHub API. You can generate a token at "
+                "https://github.com/settings/tokens/new. Note that while "
+                "working with a public repository, you don’t need to set any "
+                "scopes on the token you create."
+            )
+        self.headers = {"Authorization": "Bearer %s" % auth}
 
-        self.headers = headers
         self.gql_template = gql_template
         self.display_progress = display_progress
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,7 @@ def test_tags(tmpdir, file_regression):
     path_tmp = Path(tmpdir)
     path_output = path_tmp.joinpath("out.md")
 
-    url = "https://github.com/executablebookproject/sphinx-book-theme"
+    url = "https://github.com/executablebooks/sphinx-book-theme"
 
     # CLI with URL
     cmd = f"github-activity {url} -s v0.0.2 -u v0.0.4 -o {path_output}"

--- a/tests/test_cli/test_tags.md
+++ b/tests/test_cli/test_tags.md
@@ -1,11 +1,11 @@
 # v0.0.2...v0.0.4
-([full changelog](https://github.com/ExecutableBookProject/sphinx-book-theme/compare/v0.0.2...v0.0.4))
+([full changelog](https://github.com/executablebooks/sphinx-book-theme/compare/v0.0.2...v0.0.4))
 
 
 ## Merged PRs
-* moving expand_sections to a config value [#74](https://github.com/ExecutableBookProject/sphinx-book-theme/pull/74) ([@choldgraf](https://github.com/choldgraf))
+* moving expand_sections to a config value [#74](https://github.com/executablebooks/sphinx-book-theme/pull/74) ([@choldgraf](https://github.com/choldgraf))
 
 ## Contributors to this release
-([GitHub contributors page for this release](https://github.com/ExecutableBookProject/sphinx-book-theme/graphs/contributors?from=2020-04-22&to=2020-04-24&type=c))
+([GitHub contributors page for this release](https://github.com/executablebooks/sphinx-book-theme/graphs/contributors?from=2020-04-22&to=2020-04-24&type=c))
 
-[@choldgraf](https://github.com/search?q=repo%3AExecutableBookProject%2Fsphinx-book-theme+involves%3Acholdgraf+updated%3A2020-04-22..2020-04-24&type=Issues)
+[@choldgraf](https://github.com/search?q=repo%3Aexecutablebooks%2Fsphinx-book-theme+involves%3Acholdgraf+updated%3A2020-04-22..2020-04-24&type=Issues)


### PR DESCRIPTION
Fixes #9 and mades tests work again after ExecutableBookProject org renamed to executablebooks.

```
GITHUB_ACCESS_TOKEN= github-activity https://github.com/executablebooks/sphinx-book-theme -s v0.0.2 -u v0.0.4
Running search query:
repo:executablebooks/sphinx-book-theme


Traceback (most recent call last):
  File "/home/erik/py/bin/github-activity", line 11, in <module>
    load_entry_point('github-activity', 'console_scripts', 'github-activity')()
  File "/home/erik/dev/choldgraf/github-activity/github_activity/cli.py", line 97, in main
    strip_brackets=bool(args.strip_brackets),
  File "/home/erik/dev/choldgraf/github-activity/github_activity/github_activity.py", line 182, in generate_activity_md
    target, since=since, until=until, kind=kind, auth=auth, cache=False
  File "/home/erik/dev/choldgraf/github-activity/github_activity/github_activity.py", line 100, in get_activity
    qu = GitHubGraphQlQuery(ii_search_query, auth=auth)
  File "/home/erik/dev/choldgraf/github-activity/github_activity/graphql.py", line 98, in __init__
    "Either the environment variable GITHUB_ACCESS_TOKEN or the "
ValueError: Either the environment variable GITHUB_ACCESS_TOKEN or the --auth flag or must be used to pass a Personal Access Token needed by the GitHub API. You can generate a token at https://github.com/settings/tokens/new. Note that while working with a public repository, you don’t need to set any scopes on the token you create.
```